### PR TITLE
Correct a single type error

### DIFF
--- a/junipervpn/tncc.py
+++ b/junipervpn/tncc.py
@@ -551,7 +551,7 @@ class TNCC:
             if cert_id not in certs:
                 logging.warn('Could not find certificate for %s', str(req_dns))
 
-        inner = ''
+        inner = b''
         if certs:
             inner += self.gen_funk_response(certs)
         inner += self.gen_policy_response(policy_objs)


### PR DESCRIPTION
Specicially, this type error:
```Python Traceback
    Traceback (most recent call last):
      File "junipervpn/vpn.py", line 393, in main
          jvpn.run()
      File "junipervpn/vpn.py", line 169, in run
          self.action_tncc()
      File "junipervpn/vpn.py", line 192, in action_tncc
          self.cj.set_cookie(t.get_cookie(dspreauth_cookie, dssignin_cookie))
      File "junipervpn/tncc.py", line 557, in get_cookie
          inner += self.gen_policy_response(policy_objs)
    TypeError: can only concatenate str (not "bytes") to str
```